### PR TITLE
fix: make timestampName argument optional

### DIFF
--- a/src/plugin/FirebaseInvoke.ts
+++ b/src/plugin/FirebaseInvoke.ts
@@ -27,10 +27,10 @@ export default class FirebaseInvokeClass {
       collection:
         | FirebaseFirestore.CollectionReference
         | FirebaseFirestore.Query
-      timestampName: string
+      timestampName?: string
     },
     filter = (data: any) => data
-  ) => {
+  ): Promise<boolean> => {
     try {
       const historyRef = this.admin
         .database()
@@ -77,7 +77,7 @@ export default class FirebaseInvokeClass {
     }
   }
 
-  public resetBatchTime = async (indexName: string) => {
+  public resetBatchTime = async (indexName: string): Promise<boolean> => {
     try {
       const historyRef = this.admin
         .database()
@@ -90,7 +90,7 @@ export default class FirebaseInvokeClass {
     }
   }
 
-  public async removeAllDataFromIndex(indexName: string[]) {
+  public async removeAllDataFromIndex(indexName: string[]): Promise<void> {
     try {
       await Promise.all(
         indexName.map((_indexName: string) =>


### PR DESCRIPTION
## Issueリンク
<!-- Closes #1234 と記述することでマージ時に自動で対象のIssueがクローズされます -->
<!-- https://help.github.com/ja/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue -->

## 概要
<!-- 例 * 変更した -->
<!-- 動作している画像やgifなどがあれば貼る -->
- timestampNameをoptionalに変更。
  - 引数をobjectで渡す場合、そのプロパティを必須引数にしておくと、例えデフォルトで引数を渡してあっても、呼び出し側で必須引数を渡さないといけない仕様になっていました。
  - Playgroundで実験した結果は下記の通りです。
![image](https://user-images.githubusercontent.com/54739129/96968769-68824e00-154c-11eb-9b6f-8723b9d71cd3.png)




## リリース時に必要な作業・確認項目
<!-- 例 * python manage.py migrateを実行 -->
<!-- 例 * masterデータのcreate batchを叩くなど -->

## 特にレビューをお願いしたい箇所
<!-- 例 - [ ] 条件: パラメータの入力が不正なパターンを検証 -->
<!-- 例 - [ ] 条件: ブラウザバックした時に挙動が正しい事を確認 -->


## その他
<!-- その他、特記すべき事項を記述 -->


